### PR TITLE
refactor : UUID 중복 예외 처리

### DIFF
--- a/src/main/java/com/example/shorturl/service/UrlService.java
+++ b/src/main/java/com/example/shorturl/service/UrlService.java
@@ -11,6 +11,7 @@ import java.util.UUID;
 import java.util.stream.IntStream;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.Cacheable;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -24,6 +25,9 @@ public class UrlService {
     @Transactional
     public String generateShortenUrl(String fullUrl){
         String uuid = generateShortUuid();
+        if(urlRepository.findById(uuid).isPresent()){
+            throw new DataIntegrityViolationException("Database constraint violation");
+        }
         Url build = Url.builder().id(uuid).url(fullUrl).build();
         urlRepository.save(build);
         return encodeDirectionId(uuid);

--- a/src/main/java/com/example/shorturl/service/UrlService.java
+++ b/src/main/java/com/example/shorturl/service/UrlService.java
@@ -11,7 +11,6 @@ import java.util.UUID;
 import java.util.stream.IntStream;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.Cacheable;
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -24,13 +23,10 @@ public class UrlService {
 
     @Transactional
     public String generateShortenUrl(String fullUrl){
-        String uuid = generateShortUuid();
-        if(urlRepository.findById(uuid).isPresent()){
-            throw new DataIntegrityViolationException("Database constraint violation");
-        }
-        Url build = Url.builder().id(uuid).url(fullUrl).build();
+        String uniqueId = generateShortUuid() + urlRepository.count();
+        Url build = Url.builder().id(uniqueId).url(fullUrl).build();
         urlRepository.save(build);
-        return encodeDirectionId(uuid);
+        return encodeDirectionId(uniqueId);
     }
     @Cacheable(value = "url", key = "#encodedDirectionId", cacheManager = "contentCacheManager")
     public String redirectUrl(String encodedDirectionId){


### PR DESCRIPTION
해시 중복에 관한 것을 예외 처리했습니다.

> while문을 사용해서 중복값이 없을 때까지 반복을 시킬까도 고민했으나, 무한 루프의 우려도 있기에 사용자에게 다시 요청을 보내게끔 유도하도록 예외처리로 DataIntegrityViolationException을 사용했습니다.